### PR TITLE
mass-change: fix code blocks

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -29,7 +29,7 @@ $ git config --global user.name "Your Name"
 $ git config --global user.email "The email address you connect to GitHub with"
 $ git config --global color.ui "auto"
 ~~~
-{: .bash}
+{: .language-bash}
 
 Please use your own name and email address.
 This user name and email will be associated with your subsequent Git activity,
@@ -74,7 +74,7 @@ You can check your settings at any time:
 ~~~
 $ git config --list
 ~~~
-{: .bash}
+{: .language-bash}
 
 You can change your configuration as many times as you want: just use the
 same commands to choose another editor or update your email address.
@@ -87,7 +87,7 @@ same commands to choose another editor or update your email address.
 > $ git config -h
 > $ git config --help
 > ~~~
-> {: .bash}
+> {: .language-bash}
 {: .callout}
 
 [git-privacy]: https://help.github.com/articles/keeping-your-email-address-private/

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -49,7 +49,7 @@ $ git clone https://your_repository's_url
 $ cd your_repository
 $ ls -a
 ~~~
-{: .bash}
+{: .language-bash}
 
 We should see a pristine Git repository with a README file:
 
@@ -67,7 +67,7 @@ We can check that everything is set up correctly by asking Git to tell
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # On branch master

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -24,7 +24,7 @@ First, let's make sure we're all in the subdirectory we want to work in:
 ~~~
 $ pwd
 ~~~
-{: .bash}
+{: .language-bash}
 
 You should be in the subdirectory where you cloned your Git project.
 
@@ -35,7 +35,7 @@ but you can use whatever editor you like.)
 ~~~
 $ nano ToDo.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 Type the text below into the `ToDo.txt` file. Remember to save and exit you can type `CTRL + O` (then enter) followed by `CTRL + X`.
 
@@ -53,7 +53,7 @@ Conversion functions needed:
 ~~~
 $ ls
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 README.md ToDo.txt
@@ -63,7 +63,7 @@ README.md ToDo.txt
 ~~~
 $ cat ToDo.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Conversion functions needed:
@@ -80,7 +80,7 @@ Git tells us that it's noticed the new file:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -102,14 +102,14 @@ We can tell Git to track a file using `git add`:
 ~~~
 $ git add ToDo.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 and then check that the right thing happened:
 
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -132,7 +132,7 @@ we need to run one more command:
 ~~~
 $ git commit -m "Start notes on conversion tools"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master (root-commit) f22b25e] Start notes on conversion tools
@@ -163,7 +163,7 @@ If we run `git status` now:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -186,7 +186,7 @@ we can ask Git to show us the project's history using `git log`:
 ~~~
 $ git log
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
@@ -218,14 +218,14 @@ Now suppose we add more information to the ToDo.txt file. Remember to save and e
 ~~~
 $ nano ToDo.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ![Add extra lines to the existing file ToDo.txt](../fig/git-add-lines.png)
 
 ~~~
 $ cat ToDo.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Conversion functions needed:
@@ -243,7 +243,7 @@ it tells us that a file it already knows about has been modified:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -268,7 +268,7 @@ The last line is the key phrase: "no changes added to commit".
 ~~~
 $ git diff
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 diff --git a/ToDo.txt b/ToDo.txt
@@ -306,7 +306,7 @@ After reviewing our change, it's time to commit it:
 ~~~
 $ git commit -m "Add another desirable conversion tool"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -328,7 +328,7 @@ Let's fix that:
 $ git add ToDo.txt
 $ git commit -m "Add another desirable conversion tool"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master 34961b1] Add another desirable conversion tool
@@ -378,14 +378,14 @@ First, we'll add another line to the file. Remember to save and exit the file in
 ~~~
 $ nano ToDo.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ![Add extra lines to the existing file ToDo.txt](../fig/git-add-more-lines.png)
 
 ~~~
 $ cat ToDo.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 
 ~~~
@@ -402,7 +402,7 @@ Conversion functions needed:
 ~~~
 $ git diff
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 diff --git a/ToDo.txt b/ToDo.txt
@@ -427,7 +427,7 @@ and see what `git diff` reports:
 $ git add ToDo.txt
 $ git diff
 ~~~
-{: .bash}
+{: .language-bash}
 
 There is no output: as far as Git can tell,
 there's no difference between what it's been asked to save permanently
@@ -436,7 +436,7 @@ and what's currently in the directory. However, if we do this:
 ~~~
 $ git diff --staged
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 diff --git a/ToDo.txt b/ToDo.txt
@@ -459,7 +459,7 @@ Let's save our changes:
 ~~~
 $ git commit -m "Add the Degrees to Radians conversion"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master 005937f] Add the Degrees to Radians conversion
@@ -472,7 +472,7 @@ check our status:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -488,7 +488,7 @@ and look at the history of what we've done so far:
 ~~~
 $ git log
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 commit 005937fbe2a98fb83f0ade869025dc2636b4dad5
@@ -524,7 +524,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > $ git add directory
 > $ git status
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Note, our newly created empty directory `directory` does not appear in
 > the list of untracked files even if we explicitly add it (_via_ `git add`) to our
@@ -540,7 +540,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > ~~~
 > git add <directory-with-files>
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 {: .callout}
 

--- a/_episodes/06-push-pull.md
+++ b/_episodes/06-push-pull.md
@@ -44,7 +44,7 @@ Only the version of the repository on your laptop knows that other files
 ~~~
 $ git push
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Username for 'https://github.com': <ENTER YOUR GITHUB USERNAME HERE>
@@ -121,7 +121,7 @@ Back in your local repository, use the '`pull`' command to retrieve this
 ~~~
 $: git pull
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 remote: Counting objects: 3, done.

--- a/_episodes/07-ignore.md
+++ b/_episodes/07-ignore.md
@@ -21,14 +21,14 @@ Let's create a few dummy files:
 $ mkdir results
 $ touch a.dat b.dat c.dat results/a.out results/b.out
 ~~~
-{: .bash}
+{: .language-bash}
 
 and see what Git says:
 
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -54,7 +54,7 @@ We do this by creating a file in the root directory of our project called `.giti
 $ nano .gitignore
 $ cat .gitignore
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 *.dat
@@ -73,7 +73,7 @@ the output of `git status` is much cleaner:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -96,7 +96,7 @@ $ git add .gitignore
 $ git commit -m "Add the ignore file"
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # On branch master
@@ -109,7 +109,7 @@ As a bonus, using `.gitignore` helps us avoid accidentally adding to the reposit
 ~~~
 $ git add a.dat
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 The following paths are ignored by one of your .gitignore files:
@@ -126,7 +126,7 @@ We can also always see the status of ignored files if we want:
 ~~~
 $ git status --ignored
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -150,7 +150,7 @@ nothing to commit, working directory clean
 > results/data
 > results/plots
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > How would you ignore only `results/plots` and not `results/data`?
 >
@@ -206,7 +206,7 @@ nothing to commit, working directory clean
 > results/data/position/gps/info.txt
 > results/plots
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > What's the shortest `.gitignore` rule you could write to ignore all `.data`
 > files in `result/data/position/gps`? Do not ignore the `info.txt`.
@@ -226,7 +226,7 @@ nothing to commit, working directory clean
 > *.data
 > !*.data
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > What will be the result?
 >

--- a/_episodes/08-pull-request.md
+++ b/_episodes/08-pull-request.md
@@ -38,7 +38,7 @@ $ mkdir forktest
 $ cd forktest
 $ git clone https://github.com/dlstrong/swc-forklesson.git
 ~~~
-{: .bash}
+{: .language-bash}
 
 (**Why you want to change directories:** If you're still in the same directory you
 were just working in, that's where clone will put the new content too.

--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -34,7 +34,7 @@ repository:
 ~~~
 $ cat conversion.py
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # My Conversion Tools
@@ -51,7 +51,7 @@ Let's add a new convert function to one partner's copy only:
 $ nano conversion.py
 $ cat conversion.py
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # My Conversion Tools
@@ -72,7 +72,7 @@ and then push the change to GitHub:
 $ git add conversion.py
 $ git commit -m "Adding gallons2liters function"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master 5ae9631] Adding gallons2liters
@@ -83,7 +83,7 @@ $ git commit -m "Adding gallons2liters function"
 ~~~
 $ git push
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Counting objects: 3, done.
@@ -105,7 +105,7 @@ make a different change to their copy
 $ nano conversion.py
 $ cat conversion.py
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # My Conversion Tools
@@ -126,7 +126,7 @@ We can commit the change locally:
 $ git add conversion.py
 $ git commit -m "Adding hours2mintes function"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master 07ebc69] Adding hours2mintes
@@ -139,7 +139,7 @@ but Git won't let us push it to GitHub:
 ~~~
 $ git push
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 To https://github.com/biologyguy/conversions.git
@@ -165,7 +165,7 @@ Let's start by pulling:
 ~~~
 $ git pull
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 remote: Counting objects: 3, done.
@@ -186,7 +186,7 @@ and marks that conflict in the affected file:
 ~~~
 $ cat conversion.py
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # My Conversion Tools
@@ -226,7 +226,7 @@ In this case, we want both functions, so let's simply delete the
 $ nano conversion.py
 $ cat conversion.py
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # My Conversion Tools
@@ -255,7 +255,7 @@ and then commit:
 $ git add conversion.py
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -274,7 +274,7 @@ Changes to be committed:
 ~~~
 $ git commit -m "Merging changes from GitHub"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master 2abf2b1] Merging changes from GitHub
@@ -286,7 +286,7 @@ Now we can push our changes to GitHub:
 ~~~
 $ git push
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Counting objects: 6, done.
@@ -307,7 +307,7 @@ when the collaborator who made the first change pulls again:
 ~~~
 $ git pull
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 remote: Counting objects: 6, done.
@@ -328,7 +328,7 @@ We get the merged file:
 ~~~
 $ cat conversion.py
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # My Conversion Tools

--- a/_episodes/10-collab.md
+++ b/_episodes/10-collab.md
@@ -33,7 +33,7 @@ her `Desktop` folder, the Collaborator enters:
 ~~~
 $ git clone https://github.com/vlad/Vlad-conversion.git
 ~~~
-{: .bash}
+{: .language-bash}
 
 Replace the URL with the correct URL from the owner.
 
@@ -47,7 +47,7 @@ $ cd ~/Desktop/vlad-conversion
 $ nano conversion.py
 $ cat conversion.py
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 > > # My Conversion Tools
@@ -62,7 +62,7 @@ $ cat conversion.py
 $ git add conversion.py
 $ git commit -m "Implement dollars2cents function"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
  [master fc7397d] Implement dollars2cents function
@@ -75,7 +75,7 @@ Then push the change to the *Owner's repository* on GitHub:
 ~~~
 $ git push
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Counting objects: 3, done.
@@ -98,7 +98,7 @@ To download the Collaborator's changes from GitHub, the Owner now enters:
 ~~~
 $ git pull
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 remote: Counting objects: 4, done.


### PR DESCRIPTION
Carpentries switched to using `{: .language-bash}` for Bash code blocks. Updating these here.